### PR TITLE
feat: replace System.out.print with SLF4J logging and add log file config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,9 @@ target/
 /nbdist/
 /.nb-gradle/
 
+# Log files
+logs/
+*.log
+
 ### macOS ###
 .DS_Store

--- a/src/main/java/com/nirmala/logsense/AnomalyDetector.java
+++ b/src/main/java/com/nirmala/logsense/AnomalyDetector.java
@@ -1,8 +1,11 @@
 package com.nirmala.logsense;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.time.Instant;
 import java.util.*;
 
+@Slf4j  // This automatically creates a `log` object for this class
 public class AnomalyDetector {
     public AnomalyDetector() {}
 
@@ -44,15 +47,10 @@ public class AnomalyDetector {
                         double dynamicThreshold = mean + (k * stdDev);
 
                         if (currentCount >= dynamicThreshold) {
-                            System.out.println(
-                                    "ANOMALY detected at " + minute +
-                                            " | service = " + service +
-                                            " | errorCode = " + errorCode +
-                                            " | error_count = " + currentCount +
-                                            " | rolling_mean = " + mean +
-                                            " | rolling_stdDev = " + stdDev +
-                                            " | dynamic_threshold = " + dynamicThreshold
-                            );
+                            // BEFORE: System.out.println("ANOMALY detected at ...")
+                            // AFTER: log.info(...) — proper structured logging
+                            log.info("ANOMALY detected at {} | service={} | errorCode={} | error_count={} | rolling_mean={} | rolling_stdDev={} | dynamic_threshold={}",
+                                    minute, service, errorCode, currentCount, mean, stdDev, dynamicThreshold);
                             anomalyMinutes.add(minute);
                         }
                     }

--- a/src/main/java/com/nirmala/logsense/IncidentExplainer.java
+++ b/src/main/java/com/nirmala/logsense/IncidentExplainer.java
@@ -2,11 +2,13 @@ package com.nirmala.logsense;
 
 import com.nirmala.logsense.model.Incident;
 import com.nirmala.logsense.model.LogModel;
+import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 public class IncidentExplainer {
 
     public void explainIncident(
@@ -24,8 +26,10 @@ public class IncidentExplainer {
             String explanation = buildExplanation(service, errorCode, incident, totalErrors);
             incident.setExplanation(explanation);
 
-            System.out.println(explanation);
-            System.out.println("----------------------------------");
+            // BEFORE: System.out.println(explanation)
+            // AFTER: log.info(...) — structured, controllable logging
+            log.info(explanation);
+            log.info("----------------------------------");
             return;
         }
 
@@ -35,8 +39,8 @@ public class IncidentExplainer {
             String explanation = buildExplanation(service, errorCode, incident, totalErrors);
             incident.setExplanation(explanation);
 
-            System.out.println(explanation);
-            System.out.println("----------------------------------");
+            log.info(explanation);
+            log.info("----------------------------------");
             return;
         }
 
@@ -53,8 +57,8 @@ public class IncidentExplainer {
         String explanation = buildExplanation(service, errorCode, incident, totalErrors);
         incident.setExplanation(explanation);
 
-        System.out.println(explanation);
-        System.out.println("----------------------------------");
+        log.info(explanation);
+        log.info("----------------------------------");
     }
 
     private String buildExplanation(String service, String errorCode, Incident incident, int totalErrors) {

--- a/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
+++ b/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
@@ -8,6 +8,7 @@ import com.nirmala.logsense.dtos.LogAnalysisResponseDTO;
 import com.nirmala.logsense.model.Incident;
 import com.nirmala.logsense.model.LogModel;
 import com.nirmala.logsense.parser.LogParser;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -21,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 
 @Service
+@Slf4j      // This automatically creates a `log` object for this class
 public class LogAnalysisService {
     public LogAnalysisResponseDTO runAnalysis(MultipartFile file) {
         LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
@@ -54,8 +56,9 @@ public class LogAnalysisService {
 
                     } catch (Exception e) {
                         invalidLines++;
-                        System.err.println("Invalid log line: " + line);
-                    }
+                        // BEFORE: System.err.println("Invalid log line: " + line)
+                        // AFTER: log.warn(...) — "warn" is correct here because it's not a crash, just a bad line
+                        log.warn("Invalid log line skipped: {}", line);                    }
                 }
             }
                 // Anomaly Detection
@@ -91,6 +94,9 @@ public class LogAnalysisService {
                         }
                     }
                 }
+            // BEFORE: no log at all when analysis succeeds
+            // AFTER: log info so we can see in logs when analysis finishes
+            log.info("Analysis completed successfully. totalLines={}, invalidLines={}", totalLines, invalidLines);
             response.setStatus("success");
             response.setMessage("Analysis completed successfully");
             response.setTotalLines(totalLines);
@@ -100,7 +106,9 @@ public class LogAnalysisService {
 
             return response;
             } catch (Exception e) {
-            e.printStackTrace();
+            // BEFORE: e.printStackTrace() — messy, hard to read in production
+            // AFTER: log.error(..., e) — clean, structured, includes stack trace properly
+            log.error("Analysis failed: {}", e.getMessage(), e);
             response.setStatus("failed");
             response.setMessage("Analysis failed: " + e.getMessage());
             response.setTotalLines(totalLines);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,11 @@
+# App name
+spring.application.name=logsense
+
+# Log file settings
+logging.file.name=logs/logsense.log
+logging.logback.rollingpolicy.max-file-size=10MB
+logging.logback.rollingpolicy.max-history=7
+
+# Log levels
+logging.level.root=INFO
+logging.level.com.nirmala.logsense=DEBUG


### PR DESCRIPTION
## Summary
- Replaced all System.out.println and System.err.println with SLF4J logger 
- Replaced e.printStackTrace() with proper log.error() including stack trace
- Added application.properties with log file configuration and rolling policy

## Changes
- AnomalyDetector.java — added @Slf4j, replaced System.out.println with log.info()
- IncidentExplainer.java — added @Slf4j, replaced System.out.println with log.info()
- LogAnalysisService.java — added @Slf4j, replaced System.err.println with log.warn(), replaced e.printStackTrace() with log.error()
- application.properties — added logging.file.name, rolling policy config, log levels

## Why
System.out.println has no log levels, no timestamps, no filtering, and cannot write 
to a file. SLF4J gives structured, leveled, persistent logs which are essential 
for a production log ingestion service.

## Test Plan
- [ ] Run the application and verify logs appear in logs/logsense.log
- [ ] Upload a valid log file and confirm log.info() messages appear
- [ ] Upload an invalid/empty file and confirm log.warn() and log.error() appear
- [ ] Verify logs/ is in .gitignore and not committed