### PR TITLE
feat: externalize hardcoded detection parameters to application.properties

### DIFF
--- a/src/main/java/com/nirmala/logsense/AnomalyDetector.java
+++ b/src/main/java/com/nirmala/logsense/AnomalyDetector.java
@@ -1,5 +1,6 @@
 package com.nirmala.logsense;
 
+import com.nirmala.logsense.config.AnomalyDetectionConfig;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Instant;
@@ -11,16 +12,14 @@ public class AnomalyDetector {
 
     public Map<String, Map<String, List<Instant>>> detect(
             Map<String, Map<String, Map<Instant, Integer>>> errorsPerServiceAndCode,
-            int winSize,
-            double minimumStandardDeviation,
-            int minimumSamples) {
+            AnomalyDetectionConfig config) {
 
         Map<String, Map<String, List<Instant>>> anomalies = new HashMap<>();
 
-        int windowSize = winSize;
-        double k = 2.0;
-        double minStdDev = minimumStandardDeviation;
-        int minSamples = minimumSamples;
+        int windowSize = config.getWindowSize();
+        double k = config.getThreshold();
+        double minStdDev = config.getMinimumStandardDeviation();
+        int minSamples = config.getMinimumSamples();
 
         for (Map.Entry<String, Map<String, Map<Instant, Integer>>> serviceEntry : errorsPerServiceAndCode.entrySet()) {
             String service = serviceEntry.getKey();

--- a/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
+++ b/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
@@ -1,0 +1,21 @@
+package com.nirmala.logsense.config;
+
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Getter
+@Configuration  // tells Spring this is a config class
+public class AnomalyDetectionConfig {
+        @Value("${logsense.detection.windowSize}")
+        private int windowSize;
+
+        @Value("${logsense.detection.minimumStandardDeviation}")
+        private double minimumStandardDeviation;
+
+        @Value("${logsense.detection.minimumSamples}")
+        private int minimumSamples;
+
+        @Value("${logsense.detection.threshold}")
+        private double threshold;
+}

--- a/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
+++ b/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
@@ -4,6 +4,7 @@ import com.nirmala.logsense.Aggregator;
 import com.nirmala.logsense.AnomalyDetector;
 import com.nirmala.logsense.IncidentCorrelator;
 import com.nirmala.logsense.IncidentExplainer;
+import com.nirmala.logsense.config.AnomalyDetectionConfig;
 import com.nirmala.logsense.dtos.LogAnalysisResponseDTO;
 import com.nirmala.logsense.exception.EmptyLogFileException;
 import com.nirmala.logsense.model.Incident;
@@ -25,14 +26,16 @@ import java.util.Map;
 @Service
 @Slf4j      // This automatically creates a `log` object for this class
 public class LogAnalysisService {
+    private final AnomalyDetectionConfig config;
+    // Constructor injection
+    public LogAnalysisService(AnomalyDetectionConfig config) {
+        this.config = config;
+    }
     public LogAnalysisResponseDTO runAnalysis(MultipartFile file) {
         LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
         Map<Instant, Integer> errorsPerMinute = new HashMap<>();
         Aggregator aggregator = new Aggregator();
         AnomalyDetector detector = new AnomalyDetector();
-        int windowSize = 1;
-        double minimumStandardDeviation = 1.0;
-        int minimumSamples = 1;
 
         int totalLines=0;
         int invalidLines =0;
@@ -57,8 +60,7 @@ public class LogAnalysisService {
 
                     } catch (Exception e) {
                         invalidLines++;
-                        // BEFORE: System.err.println("Invalid log line: " + line)
-                        // AFTER: log.warn(...) — "warn" is correct here because it's not a crash, just a bad line
+                        // "warn" is correct here because it's not a crash, just a bad line
                         log.warn("Invalid log line skipped: {}", line);                    }
                 }
             }
@@ -66,9 +68,7 @@ public class LogAnalysisService {
                 Map<String, Map<String, List<Instant>>> anomalyMap =
                         detector.detect(
                                 aggregator.getErrorCount(),
-                                windowSize,
-                                minimumStandardDeviation,
-                                minimumSamples
+                                config
                         );
 
                 // Incident Grouping / Correlation

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,3 +12,10 @@ logging.level.com.nirmala.logsense=DEBUG
 
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
+
+
+# Anomaly Detection Config
+logsense.detection.windowSize=5
+logsense.detection.minimumStandardDeviation=1.0
+logsense.detection.minimumSamples=1
+logsense.detection.threshold=2.0


### PR DESCRIPTION
## Summary
- Created AnomalyDetectionConfig class to hold detection parameters
- Moved all hardcoded values to application.properties
- Updated AnomalyDetector to accept config object instead of individual params
- Updated LogAnalysisService to inject and pass config

## Why
Hardcoded values require source code changes and redeployment to tune 
detection sensitivity. Externalizing to application.properties allows 
per-environment configuration without touching code.

## Test Plan
- [ ] App starts without errors
- [ ] Analysis runs correctly with values from application.properties
- [ ] Change windowSize in application.properties and verify detection changes