### PR TITLE
feat: add Spring beans and dependency injection to core classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # LogSignals
+
 Explainable Anomaly Detection System.
 
-A Java-based log monitoring system enabling proactive anomaly detection and real-time alerts for improved system reliability.
+A Java-based log monitoring system enabling proactive anomaly detection and real-time alerts for improved system
+reliability.

--- a/src/main/java/com/nirmala/logsense/Aggregator.java
+++ b/src/main/java/com/nirmala/logsense/Aggregator.java
@@ -1,6 +1,9 @@
 package com.nirmala.logsense;
 
 import com.nirmala.logsense.model.LogModel;
+import org.springframework.context.annotation.Scope;
+import org.springframework.stereotype.Component;
+
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -8,7 +11,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-public class Aggregator{
+@Component
+@Scope("prototype")  // creates a NEW instance for every injection
+public class Aggregator {
 
     // service -> errorCode -> minute -> count
     private final Map<String, Map<String, Map<Instant, Integer>>> errorCount = new HashMap<>();
@@ -46,6 +51,7 @@ public class Aggregator{
     public Map<String, Map<String, Map<Instant, List<LogModel>>>> getErrorLogs() {
         return errorLogs;
     }
+
     public Map<Instant, Integer> getTotalErrorsPerMinute() {
         Map<Instant, Integer> totalErrorsPerMinute = new HashMap<>();
 

--- a/src/main/java/com/nirmala/logsense/AnomalyDetector.java
+++ b/src/main/java/com/nirmala/logsense/AnomalyDetector.java
@@ -2,13 +2,16 @@ package com.nirmala.logsense;
 
 import com.nirmala.logsense.config.AnomalyDetectionConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.*;
 
 @Slf4j  // This automatically creates a `log` object for this class
+@Component
 public class AnomalyDetector {
-    public AnomalyDetector() {}
+    public AnomalyDetector() {
+    }
 
     public Map<String, Map<String, List<Instant>>> detect(
             Map<String, Map<String, Map<Instant, Integer>>> errorsPerServiceAndCode,

--- a/src/main/java/com/nirmala/logsense/IncidentCorrelator.java
+++ b/src/main/java/com/nirmala/logsense/IncidentCorrelator.java
@@ -1,10 +1,12 @@
 package com.nirmala.logsense;
 
 import com.nirmala.logsense.model.Incident;
+import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.*;
 
+@Component
 public class IncidentCorrelator {
 
     public Map<String, Map<String, List<Incident>>> group(
@@ -66,18 +68,6 @@ public class IncidentCorrelator {
         return incidents;
     }
 }
-
-
-
-
-
-
-
-
-
-
-
-
 
 
 //public class IncidentCorrelator {

--- a/src/main/java/com/nirmala/logsense/IncidentExplainer.java
+++ b/src/main/java/com/nirmala/logsense/IncidentExplainer.java
@@ -3,12 +3,14 @@ package com.nirmala.logsense;
 import com.nirmala.logsense.model.Incident;
 import com.nirmala.logsense.model.LogModel;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
 
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 
 @Slf4j
+@Component
 public class IncidentExplainer {
 
     public void explainIncident(

--- a/src/main/java/com/nirmala/logsense/MainApp.java
+++ b/src/main/java/com/nirmala/logsense/MainApp.java
@@ -5,7 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class MainApp {
-public static void main(String[] args){
-    SpringApplication.run(MainApp.class, args);
-}
+    public static void main(String[] args) {
+        SpringApplication.run(MainApp.class, args);
+    }
 }

--- a/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
+++ b/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
@@ -7,15 +7,15 @@ import org.springframework.context.annotation.Configuration;
 @Getter
 @Configuration  // tells Spring this is a config class
 public class AnomalyDetectionConfig {
-        @Value("${logsense.detection.windowSize}")
-        private int windowSize;
+    @Value("${logsense.detection.windowSize}")
+    private int windowSize;
 
-        @Value("${logsense.detection.minimumStandardDeviation}")
-        private double minimumStandardDeviation;
+    @Value("${logsense.detection.minimumStandardDeviation}")
+    private double minimumStandardDeviation;
 
-        @Value("${logsense.detection.minimumSamples}")
-        private int minimumSamples;
+    @Value("${logsense.detection.minimumSamples}")
+    private int minimumSamples;
 
-        @Value("${logsense.detection.threshold}")
-        private double threshold;
+    @Value("${logsense.detection.threshold}")
+    private double threshold;
 }

--- a/src/main/java/com/nirmala/logsense/controller/LogAnalysisController.java
+++ b/src/main/java/com/nirmala/logsense/controller/LogAnalysisController.java
@@ -3,7 +3,10 @@ package com.nirmala.logsense.controller;
 import com.nirmala.logsense.dtos.LogAnalysisResponseDTO;
 import com.nirmala.logsense.service.LogAnalysisService;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.HashMap;
@@ -22,7 +25,7 @@ public class LogAnalysisController {
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public LogAnalysisResponseDTO analyzeLogs(@RequestPart("file") MultipartFile file) {
         Map<String, String> response = new HashMap<>();
-       return logService.runAnalysis(file);
+        return logService.runAnalysis(file);
 
     }
 }

--- a/src/main/java/com/nirmala/logsense/model/Incident.java
+++ b/src/main/java/com/nirmala/logsense/model/Incident.java
@@ -4,22 +4,32 @@ import java.time.Instant;
 
 public class Incident {
 
-        private final Instant start;
-        private Instant end;
-        private String explanation;
+    private final Instant start;
+    private Instant end;
+    private String explanation;
 
-        public Incident(Instant start, Instant end) {
-            this.start = start;
-            this.end = end;
-        }
-
-        public Instant getStart() { return start; }
-        public Instant getEnd() { return end; }
-        public void setEnd(Instant end) { this.end = end; }
-        public String getExplanation() {
-          return explanation;
-        }
-        public void setExplanation(String explanation) {
-         this.explanation = explanation;
-        }
+    public Incident(Instant start, Instant end) {
+        this.start = start;
+        this.end = end;
     }
+
+    public Instant getStart() {
+        return start;
+    }
+
+    public Instant getEnd() {
+        return end;
+    }
+
+    public void setEnd(Instant end) {
+        this.end = end;
+    }
+
+    public String getExplanation() {
+        return explanation;
+    }
+
+    public void setExplanation(String explanation) {
+        this.explanation = explanation;
+    }
+}

--- a/src/main/java/com/nirmala/logsense/model/LogModel.java
+++ b/src/main/java/com/nirmala/logsense/model/LogModel.java
@@ -19,11 +19,25 @@ public class LogModel {
         this.message = message;
     }
 
-    public Instant getTimestamp() { return timestamp; }
-    public String getLevel() { return level; }
-    public String getService() { return service; }
-    public String getErrorCode() { return errorCode; }
-    public String getMessage() { return message; }
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public String getLevel() {
+        return level;
+    }
+
+    public String getService() {
+        return service;
+    }
+
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public String getMessage() {
+        return message;
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/com/nirmala/logsense/parser/LogParser.java
+++ b/src/main/java/com/nirmala/logsense/parser/LogParser.java
@@ -4,27 +4,29 @@ package com.nirmala.logsense.parser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nirmala.logsense.model.LogModel;
+
 import java.time.Instant;
 
 public class LogParser {
 
-        private static final ObjectMapper mapper = new ObjectMapper();
-        public static LogModel parse(String logLine) throws Exception {
+    private static final ObjectMapper mapper = new ObjectMapper();
 
-            JsonNode node = mapper.readTree(logLine);
+    public static LogModel parse(String logLine) throws Exception {
 
-            Instant timestamp = Instant.parse(node.get("timestamp").asText());
-            String level = node.get("level").asText();
-            String service = node.get("service").asText();
-            String message = node.get("message").asText();
+        JsonNode node = mapper.readTree(logLine);
 
-            String errorCode = node.has("errorCode")
-                    ? node.get("errorCode").asText()
-                    : null;
+        Instant timestamp = Instant.parse(node.get("timestamp").asText());
+        String level = node.get("level").asText();
+        String service = node.get("service").asText();
+        String message = node.get("message").asText();
 
-            return new LogModel(timestamp, level, service, errorCode, message);
-        }
+        String errorCode = node.has("errorCode")
+                ? node.get("errorCode").asText()
+                : null;
+
+        return new LogModel(timestamp, level, service, errorCode, message);
     }
+}
 
 
 

--- a/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
+++ b/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
@@ -11,6 +11,7 @@ import com.nirmala.logsense.model.Incident;
 import com.nirmala.logsense.model.LogModel;
 import com.nirmala.logsense.parser.LogParser;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationContext;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -26,19 +27,32 @@ import java.util.Map;
 @Service
 @Slf4j      // This automatically creates a `log` object for this class
 public class LogAnalysisService {
+    private final ApplicationContext context; // Spring's bean factory
+    private final Aggregator aggregator;
+    private final AnomalyDetector detector;
+    private final IncidentCorrelator correlator;
+    private final IncidentExplainer explainer;
     private final AnomalyDetectionConfig config;
+
     // Constructor injection
-    public LogAnalysisService(AnomalyDetectionConfig config) {
+    public LogAnalysisService(Aggregator aggregator, AnomalyDetector detector, IncidentCorrelator correlator, IncidentExplainer explainer, AnomalyDetectionConfig config, ApplicationContext context) {
+        this.context = context;
+        this.aggregator = aggregator;
+        this.detector = detector;
+        this.correlator = correlator;
+        this.explainer = explainer;
         this.config = config;
     }
+
     public LogAnalysisResponseDTO runAnalysis(MultipartFile file) {
+        // Get a FRESH Aggregator for every request
+        Aggregator aggregator = context.getBean(Aggregator.class);
         LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
         Map<Instant, Integer> errorsPerMinute = new HashMap<>();
-        Aggregator aggregator = new Aggregator();
         AnomalyDetector detector = new AnomalyDetector();
 
-        int totalLines=0;
-        int invalidLines =0;
+        int totalLines = 0;
+        int invalidLines = 0;
         try {
 
             if (file == null || file.isEmpty()) {
@@ -61,40 +75,41 @@ public class LogAnalysisService {
                     } catch (Exception e) {
                         invalidLines++;
                         // "warn" is correct here because it's not a crash, just a bad line
-                        log.warn("Invalid log line skipped: {}", line);                    }
-                }
-            }
-                // Anomaly Detection
-                Map<String, Map<String, List<Instant>>> anomalyMap =
-                        detector.detect(
-                                aggregator.getErrorCount(),
-                                config
-                        );
-
-                // Incident Grouping / Correlation
-                IncidentCorrelator correlator = new IncidentCorrelator();
-
-                Map<String, Map<String, List<Incident>>> incidentsByServiceAndErrorCode =
-                        correlator.group(anomalyMap);
-
-                IncidentExplainer explainer = new IncidentExplainer();
-
-                for (Map.Entry<String, Map<String, List<Incident>>> serviceEntry : incidentsByServiceAndErrorCode.entrySet()) {
-                    String service = serviceEntry.getKey();
-
-                    for (Map.Entry<String, List<Incident>> errorEntry : serviceEntry.getValue().entrySet()) {
-                        String errorCode = errorEntry.getKey();
-
-                        for (Incident incident : errorEntry.getValue()) {
-                            explainer.explainIncident(
-                                    service,
-                                    errorCode,
-                                    incident,
-                                    aggregator.getErrorLogs()
-                            );
-                        }
+                        log.warn("Invalid log line skipped: {}", line);
                     }
                 }
+            }
+            // Anomaly Detection
+            Map<String, Map<String, List<Instant>>> anomalyMap =
+                    detector.detect(
+                            aggregator.getErrorCount(),
+                            config
+                    );
+
+            // Incident Grouping / Correlation
+            IncidentCorrelator correlator = new IncidentCorrelator();
+
+            Map<String, Map<String, List<Incident>>> incidentsByServiceAndErrorCode =
+                    correlator.group(anomalyMap);
+
+            IncidentExplainer explainer = new IncidentExplainer();
+
+            for (Map.Entry<String, Map<String, List<Incident>>> serviceEntry : incidentsByServiceAndErrorCode.entrySet()) {
+                String service = serviceEntry.getKey();
+
+                for (Map.Entry<String, List<Incident>> errorEntry : serviceEntry.getValue().entrySet()) {
+                    String errorCode = errorEntry.getKey();
+
+                    for (Incident incident : errorEntry.getValue()) {
+                        explainer.explainIncident(
+                                service,
+                                errorCode,
+                                incident,
+                                aggregator.getErrorLogs()
+                        );
+                    }
+                }
+            }
             // BEFORE: no log at all when analysis succeeds
             // AFTER: log info so we can see in logs when analysis finishes
             log.info("Analysis completed successfully. totalLines={}, invalidLines={}", totalLines, invalidLines);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,19 +1,14 @@
 # App name
 spring.application.name=logsense
-
 # Log file settings
 logging.file.name=logs/logsense.log
 logging.logback.rollingpolicy.max-file-size=10MB
 logging.logback.rollingpolicy.max-history=7
-
 # Log levels
 logging.level.root=INFO
 logging.level.com.nirmala.logsense=DEBUG
-
 spring.servlet.multipart.max-file-size=10MB
 spring.servlet.multipart.max-request-size=10MB
-
-
 # Anomaly Detection Config
 logsense.detection.windowSize=5
 logsense.detection.minimumStandardDeviation=1.0


### PR DESCRIPTION
## Summary
- Added @Component to Aggregator, AnomalyDetector, IncidentCorrelator, IncidentExplainer
- Replaced manual new keyword with constructor injection in LogAnalysisService
- Added @Scope("prototype") + ApplicationContext to Aggregator

## Why
Classes were manually created with new on every request, bypassing 
Spring's DI system entirely. Constructor injection makes dependencies 
explicit and enables proper unit testing.

Also, Aggregator holds data in memory while processing logs. Spring 
beans are singletons by default meaning one shared instance across all 
requests. Without prototype scope, data from one upload would mix into 
the next upload giving wrong results. Prototype scope tells Spring to 
create a fresh empty Aggregator for every request keeping each upload 
completely isolated.

## Test Plan
- [ ] App starts without errors
- [ ] Single file upload analysis works correctly
- [ ] Upload file A then immediately upload file B — 
      results should only contain data from their own file, not mixed