### PR TITLE
refactor: split LogAnalysisService into single responsibility methods

### DIFF
--- a/src/main/java/com/nirmala/logsense/aggregator/Aggregator.java
+++ b/src/main/java/com/nirmala/logsense/aggregator/Aggregator.java
@@ -15,7 +15,8 @@ import java.util.Map;
 @Component
 @Scope("prototype")  // creates a NEW instance for every injection
 public class Aggregator {
-
+    private int totalLines;
+    private int invalidLines;
     // service -> errorCode -> minute -> count
     private final Map<AggregationKey, Integer> errorCount = new HashMap<>();
 
@@ -62,5 +63,9 @@ public class Aggregator {
         }
         return totalErrorsPerMinute;
     }
+    public int getTotalLines() { return totalLines; }
+    public int getInvalidLines() { return invalidLines; }
+    public void setTotalLines(int totalLines) { this.totalLines = totalLines; }
+    public void setInvalidLines(int invalidLines) { this.invalidLines = invalidLines; }
 }
 

--- a/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
+++ b/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
@@ -1,12 +1,12 @@
 package com.nirmala.logsense.service;
 
 import com.nirmala.logsense.aggregator.Aggregator;
-import com.nirmala.logsense.detector.AnomalyDetector;
-import com.nirmala.logsense.correlator.IncidentCorrelator;
-import com.nirmala.logsense.explainer.IncidentExplainer;
 import com.nirmala.logsense.config.AnomalyDetectionConfig;
+import com.nirmala.logsense.correlator.IncidentCorrelator;
+import com.nirmala.logsense.detector.AnomalyDetector;
 import com.nirmala.logsense.dto.LogAnalysisResponseDTO;
 import com.nirmala.logsense.exception.EmptyLogFileException;
+import com.nirmala.logsense.explainer.IncidentExplainer;
 import com.nirmala.logsense.model.Incident;
 import com.nirmala.logsense.model.LogModel;
 import com.nirmala.logsense.parser.LogParser;
@@ -20,123 +20,184 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Service
-@Slf4j      // This automatically creates a `log` object for this class
 public class LogAnalysisService {
-    private final ApplicationContext context; // Spring's bean factory
-    private final Aggregator aggregator;
+
+    private final ApplicationContext context;
     private final AnomalyDetector detector;
     private final IncidentCorrelator correlator;
     private final IncidentExplainer explainer;
     private final AnomalyDetectionConfig config;
 
-    // Constructor injection
-    public LogAnalysisService(Aggregator aggregator, AnomalyDetector detector, IncidentCorrelator correlator, IncidentExplainer explainer, AnomalyDetectionConfig config, ApplicationContext context) {
+    public LogAnalysisService(
+            ApplicationContext context,
+            AnomalyDetector detector,
+            IncidentCorrelator correlator,
+            IncidentExplainer explainer,
+            AnomalyDetectionConfig config) {
         this.context = context;
-        this.aggregator = aggregator;
         this.detector = detector;
         this.correlator = correlator;
         this.explainer = explainer;
         this.config = config;
     }
 
+    // ─────────────────────────────────────────
+    // PUBLIC — orchestrates the full pipeline
+    // ─────────────────────────────────────────
     public LogAnalysisResponseDTO runAnalysis(MultipartFile file) {
-        // Get a FRESH Aggregator for every request
-        Aggregator aggregator = context.getBean(Aggregator.class);
-        LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
-        Map<Instant, Integer> errorsPerMinute = new HashMap<>();
-        AnomalyDetector detector = new AnomalyDetector();
-
-        int totalLines = 0;
-        int invalidLines = 0;
         try {
+            validateFile(file);
 
-            if (file == null || file.isEmpty()) {
-                throw new EmptyLogFileException("Uploaded log file is empty");
-            }
-            try (InputStream is = file.getInputStream();
-                 BufferedReader reader = new BufferedReader(
-                         new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            Aggregator aggregator = context.getBean(Aggregator.class);
+            parseAndAggregate(file, aggregator);
 
-                String line;
-                while ((line = reader.readLine()) != null) {
-                    totalLines++;
-                    try {
-                        // log parsing
-                        LogModel log = LogParser.parse(line);
-
-                        // log aggregation
-                        aggregator.add(log);
-
-                    } catch (Exception e) {
-                        invalidLines++;
-                        // "warn" is correct here because it's not a crash, just a bad line
-                        log.warn("Invalid log line skipped: {}", line);
-                    }
-                }
-            }
-            // Anomaly Detection
             Map<String, Map<String, List<Instant>>> anomalyMap =
-                    detector.detect(
-                            aggregator.getErrorCount(),
-                            config
-                    );
+                    detectAnomalies(aggregator);
 
-            // Incident Grouping / Correlation
-            IncidentCorrelator correlator = new IncidentCorrelator();
+            Map<String, Map<String, List<Incident>>> incidents =
+                    correlateIncidents(anomalyMap);
 
-            Map<String, Map<String, List<Incident>>> incidentsByServiceAndErrorCode =
-                    correlator.group(anomalyMap);
+            explainIncidents(incidents, aggregator);
 
-            IncidentExplainer explainer = new IncidentExplainer();
+            return buildSuccessResponse(
+                    aggregator.getTotalLines(),
+                    aggregator.getInvalidLines(),
+                    anomalyMap,
+                    incidents
+            );
 
-            for (Map.Entry<String, Map<String, List<Incident>>> serviceEntry : incidentsByServiceAndErrorCode.entrySet()) {
-                String service = serviceEntry.getKey();
-
-                for (Map.Entry<String, List<Incident>> errorEntry : serviceEntry.getValue().entrySet()) {
-                    String errorCode = errorEntry.getKey();
-
-                    for (Incident incident : errorEntry.getValue()) {
-                        explainer.explainIncident(
-                                service,
-                                errorCode,
-                                incident,
-                                aggregator.getErrorLogs()
-                        );
-                    }
-                }
-            }
-            // BEFORE: no log at all when analysis succeeds
-            // AFTER: log info so we can see in logs when analysis finishes
-            log.info("Analysis completed successfully. totalLines={}, invalidLines={}", totalLines, invalidLines);
-            response.setStatus("success");
-            response.setMessage("Analysis completed successfully");
-            response.setTotalLines(totalLines);
-            response.setInvalidLines(invalidLines);
-            response.setAnomalies(anomalyMap);
-            response.setIncidents(incidentsByServiceAndErrorCode);
-
-            return response;
         } catch (EmptyLogFileException e) {
             log.error("Empty file error: {}", e.getMessage());
-            response.setStatus("failed");
-            response.setMessage(e.getMessage());
-            response.setTotalLines(totalLines);
-            response.setInvalidLines(invalidLines);
-            return response;
+            return buildFailureResponse(e.getMessage());
 
         } catch (Exception e) {
             log.error("Analysis failed: {}", e.getMessage(), e);
-            response.setStatus("failed");
-            response.setMessage("Analysis failed: " + e.getMessage());
-            response.setTotalLines(totalLines);
-            response.setInvalidLines(invalidLines);
-            return response;
+            return buildFailureResponse("Analysis failed: " + e.getMessage());
         }
     }
-}
 
+    // ─────────────────────────────────────────
+    // STEP 1 — Validate file
+    // ─────────────────────────────────────────
+    private void validateFile(MultipartFile file) {
+        if (file == null || file.isEmpty()) {
+            throw new EmptyLogFileException("Uploaded log file is empty");
+        }
+    }
+
+    // ─────────────────────────────────────────
+    // STEP 2 — Parse lines and aggregate
+    // ─────────────────────────────────────────
+    private void parseAndAggregate(MultipartFile file, Aggregator aggregator) {
+        int totalLines = 0;
+        int invalidLines = 0;
+
+        try (InputStream is = file.getInputStream();
+             BufferedReader reader = new BufferedReader(
+                     new InputStreamReader(is, StandardCharsets.UTF_8))) {
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                totalLines++;
+                try {
+                    LogModel logModel = LogParser.parse(line);
+                    aggregator.add(logModel);
+                } catch (Exception e) {
+                    invalidLines++;
+                    log.warn("Invalid log line skipped: {}", line);
+                }
+            }
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to read log file", e);
+        }
+
+        aggregator.setTotalLines(totalLines);
+        aggregator.setInvalidLines(invalidLines);
+
+        log.info("Parsing complete. totalLines={}, invalidLines={}",
+                totalLines, invalidLines);
+    }
+
+    // ─────────────────────────────────────────
+    // STEP 3 — Detect anomalies
+    // ─────────────────────────────────────────
+    private Map<String, Map<String, List<Instant>>> detectAnomalies(Aggregator aggregator) {
+        Map<String, Map<String, List<Instant>>> anomalyMap =
+                detector.detect(aggregator.getErrorCount(), config);
+        log.info("Anomaly detection complete. anomaliesFound={}", anomalyMap.size());
+        return anomalyMap;
+    }
+
+    // ─────────────────────────────────────────
+    // STEP 4 — Correlate incidents
+    // ─────────────────────────────────────────
+    private Map<String, Map<String, List<Incident>>> correlateIncidents(
+            Map<String, Map<String, List<Instant>>> anomalyMap) {
+        Map<String, Map<String, List<Incident>>> incidents =
+                correlator.group(anomalyMap);
+        log.info("Incident correlation complete. incidentsFound={}", incidents.size());
+        return incidents;
+    }
+
+    // ─────────────────────────────────────────
+    // STEP 5 — Explain incidents
+    // ─────────────────────────────────────────
+    private void explainIncidents(
+            Map<String, Map<String, List<Incident>>> incidents,
+            Aggregator aggregator) {
+
+        for (Map.Entry<String, Map<String, List<Incident>>> serviceEntry
+                : incidents.entrySet()) {
+            String service = serviceEntry.getKey();
+
+            for (Map.Entry<String, List<Incident>> errorEntry
+                    : serviceEntry.getValue().entrySet()) {
+                String errorCode = errorEntry.getKey();
+
+                for (Incident incident : errorEntry.getValue()) {
+                    explainer.explainIncident(
+                            service,
+                            errorCode,
+                            incident,
+                            aggregator.getErrorLogs()
+                    );
+                }
+            }
+        }
+    }
+
+    // ─────────────────────────────────────────
+    // STEP 6 — Build responses
+    // ─────────────────────────────────────────
+    private LogAnalysisResponseDTO buildSuccessResponse(
+            int totalLines,
+            int invalidLines,
+            Map<String, Map<String, List<Instant>>> anomalyMap,
+            Map<String, Map<String, List<Incident>>> incidents) {
+
+        LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
+        response.setStatus("success");
+        response.setMessage("Analysis completed successfully");
+        response.setTotalLines(totalLines);
+        response.setInvalidLines(invalidLines);
+        response.setAnomalies(anomalyMap);
+        response.setIncidents(incidents);
+
+        log.info("Analysis completed successfully. totalLines={}, invalidLines={}",
+                totalLines, invalidLines);
+        return response;
+    }
+
+    private LogAnalysisResponseDTO buildFailureResponse(String message) {
+        LogAnalysisResponseDTO response = new LogAnalysisResponseDTO();
+        response.setStatus("failed");
+        response.setMessage(message);
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary
- Split runAnalysis() into 7 private methods each with one responsibility
- Removed unused errorsPerMinute variable
- Added totalLines and invalidLines tracking to Aggregator

## Why
runAnalysis() was handling validation, file reading, parsing, aggregation,
detection, correlation, explanation and response building all in one method.
Each step is now its own method making the code easy to read, test and debug.

## Test Plan
- [ ] mvn clean compile passes
- [ ] App starts successfully
- [ ] File upload returns correct analysis results
- [ ] Invalid lines counted correctly in response