### PR TITLE
test: add unit tests for AnomalyDetector, IncidentCorrelator classes

### DIFF
--- a/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
+++ b/src/main/java/com/nirmala/logsense/config/AnomalyDetectionConfig.java
@@ -1,10 +1,14 @@
 package com.nirmala.logsense.config;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 
 @Getter
+@Setter
+@NoArgsConstructor
 @Configuration  // tells Spring this is a config class
 public class AnomalyDetectionConfig {
     @Value("${logsense.detection.windowSize}")

--- a/src/test/java/com/nirmala/logsense/correlator/IncidentCorrelatorTest.java
+++ b/src/test/java/com/nirmala/logsense/correlator/IncidentCorrelatorTest.java
@@ -1,0 +1,89 @@
+package com.nirmala.logsense.correlator;
+
+import com.nirmala.logsense.model.Incident;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IncidentCorrelatorTest {
+
+    private IncidentCorrelator correlator;
+
+    @BeforeEach
+    void setUp() {
+        correlator = new IncidentCorrelator();
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoAnomaliesExist() {
+        // Arrange
+        Map<String, Map<String, List<Instant>>> anomalies = new HashMap<>();
+
+        // Act
+        Map<String, Map<String, List<Incident>>> result =
+                correlator.group(anomalies);
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldGroupConsecutiveMinutesIntoOneIncident() {
+        // Arrange — 3 consecutive anomaly minutes
+        Instant t1 = Instant.parse("2026-04-15T10:00:00Z");
+        Instant t2 = Instant.parse("2026-04-15T10:01:00Z");
+        Instant t3 = Instant.parse("2026-04-15T10:02:00Z");
+
+        Map<String, Map<String, List<Instant>>> anomalies = new HashMap<>();
+        anomalies
+                .computeIfAbsent("auth-service", s -> new HashMap<>())
+                .put("ERR_500", List.of(t1, t2, t3));
+
+        // Act
+        Map<String, Map<String, List<Incident>>> result =
+                correlator.group(anomalies);
+
+        // Assert — should be ONE incident spanning t1 to t3
+        List<Incident> incidents = result.get("auth-service").get("ERR_500");
+        assertEquals(1, incidents.size());
+        assertEquals(t1, incidents.get(0).getStart());
+        assertEquals(t3, incidents.get(0).getEnd());
+    }
+
+    @Test
+    void shouldCreateTwoIncidentsWhenMinutesAreNotConsecutive() {
+        // Arrange — gap between t2 and t3
+        Instant t1 = Instant.parse("2026-04-15T10:00:00Z");
+        Instant t2 = Instant.parse("2026-04-15T10:01:00Z");
+        Instant t3 = Instant.parse("2026-04-15T10:05:00Z"); // gap!
+
+        Map<String, Map<String, List<Instant>>> anomalies = new HashMap<>();
+        anomalies
+                .computeIfAbsent("auth-service", s -> new HashMap<>())
+                .put("ERR_500", List.of(t1, t2, t3));
+
+        // Act
+        Map<String, Map<String, List<Incident>>> result =
+                correlator.group(anomalies);
+
+        // Assert — should be TWO separate incidents
+        List<Incident> incidents = result.get("auth-service").get("ERR_500");
+        assertEquals(2, incidents.size());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenAnomalyMapIsNull() {
+        // Act
+        Map<String, Map<String, List<Incident>>> result =
+                correlator.group(null);
+
+        // Assert
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/nirmala/logsense/detector/AnomalyDetectorTest.java
+++ b/src/test/java/com/nirmala/logsense/detector/AnomalyDetectorTest.java
@@ -1,0 +1,92 @@
+package com.nirmala.logsense.detector;
+
+import com.nirmala.logsense.config.AnomalyDetectionConfig;
+import com.nirmala.logsense.model.AggregationKey;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AnomalyDetectorTest {
+
+    private AnomalyDetector detector;
+    private AnomalyDetectionConfig config;
+
+    @BeforeEach
+    void setUp() {
+        detector = new AnomalyDetector();
+
+        // fake config — use simple values for testing
+        config = new AnomalyDetectionConfig();
+        config.setWindowSize(3);
+        config.setMinimumSamples(3);
+        config.setMinimumStandardDeviation(1.0);
+        config.setThreshold(2.0);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenNoErrorsExist() {
+        // Arrange — empty input
+        Map<AggregationKey, Integer> errorCount = new HashMap<>();
+
+        // Act — run detection
+        Map<String, Map<String, List<Instant>>> result =
+                detector.detect(errorCount, config);
+
+        // Assert — should be empty
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldDetectAnomalyWhenCountSpikeOccurs() {
+        // Arrange — simulate normal counts then a spike
+        Map<AggregationKey, Integer> errorCount = new HashMap<>();
+
+        Instant t1 = Instant.parse("2026-04-15T10:00:00Z");
+        Instant t2 = Instant.parse("2026-04-15T10:01:00Z");
+        Instant t3 = Instant.parse("2026-04-15T10:02:00Z");
+        Instant t4 = Instant.parse("2026-04-15T10:03:00Z"); // spike
+
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t1), 5);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t2), 5);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t3), 5);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t4), 100); // spike!
+
+        // Act
+        Map<String, Map<String, List<Instant>>> result =
+                detector.detect(errorCount, config);
+
+        // Assert — anomaly should be detected
+        assertTrue(result.containsKey("auth-service"));
+        assertTrue(result.get("auth-service").containsKey("ERR_500"));
+        assertFalse(result.get("auth-service").get("ERR_500").isEmpty());
+    }
+
+    @Test
+    void shouldNotDetectAnomalyWhenCountsAreNormal() {
+        // Arrange — all counts are similar, no spike
+        Map<AggregationKey, Integer> errorCount = new HashMap<>();
+
+        Instant t1 = Instant.parse("2026-04-15T10:00:00Z");
+        Instant t2 = Instant.parse("2026-04-15T10:01:00Z");
+        Instant t3 = Instant.parse("2026-04-15T10:02:00Z");
+        Instant t4 = Instant.parse("2026-04-15T10:03:00Z");
+
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t1), 5);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t2), 5);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t3), 6);
+        errorCount.put(new AggregationKey("auth-service", "ERR_500", t4), 5);
+
+        // Act
+        Map<String, Map<String, List<Instant>>> result =
+                detector.detect(errorCount, config);
+
+        // Assert — no anomaly
+        assertTrue(result.isEmpty());
+    }
+}

--- a/src/test/java/com/nirmala/logsense/service/LogAnalysisServiceTest.java
+++ b/src/test/java/com/nirmala/logsense/service/LogAnalysisServiceTest.java
@@ -1,0 +1,86 @@
+package com.nirmala.logsense.service;
+
+import com.nirmala.logsense.aggregator.Aggregator;
+import com.nirmala.logsense.config.AnomalyDetectionConfig;
+import com.nirmala.logsense.correlator.IncidentCorrelator;
+import com.nirmala.logsense.detector.AnomalyDetector;
+import com.nirmala.logsense.dto.LogAnalysisResponseDTO;
+import com.nirmala.logsense.explainer.IncidentExplainer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationContext;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.util.HashMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class LogAnalysisServiceTest {
+
+    // @Mock creates a fake version of each dependency
+    @Mock private ApplicationContext context;
+    @Mock private AnomalyDetector detector;
+    @Mock private IncidentCorrelator correlator;
+    @Mock private IncidentExplainer explainer;
+    @Mock private AnomalyDetectionConfig config;
+    @Mock private Aggregator aggregator;
+
+    private LogAnalysisService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new LogAnalysisService(
+                context, detector, correlator, explainer, config
+        );
+
+    }
+
+    @Test
+    void shouldReturnFailedResponseWhenFileIsEmpty() {
+        // Arrange — empty file
+        MockMultipartFile emptyFile = new MockMultipartFile(
+                "file", "test.log", "text/plain", new byte[0]
+        );
+
+        // Act
+        LogAnalysisResponseDTO result = service.runAnalysis(emptyFile);
+
+        // Assert
+        assertEquals("failed", result.getStatus());
+        assertEquals("Uploaded log file is empty", result.getMessage());
+    }
+
+    @Test
+    void shouldReturnFailedResponseWhenFileIsNull() {
+        // Act
+        LogAnalysisResponseDTO result = service.runAnalysis(null);
+
+        // Assert
+        assertEquals("failed", result.getStatus());
+    }
+
+    @Test
+    void shouldReturnSuccessResponseForValidFile() throws Exception {
+        // FIX 1 — tell mock context to return mock aggregator
+        when(context.getBean(Aggregator.class)).thenReturn(aggregator);
+        when(detector.detect(any(), any())).thenReturn(new HashMap<>());
+        when(correlator.group(any())).thenReturn(new HashMap<>());
+
+        // FIX 2 — use whatever format your LogParser actually expects
+        // check your LogParser.parse() to see what format it needs
+        String logContent = "your correct log format here";
+        MockMultipartFile validFile = new MockMultipartFile(
+                "file", "test.log", "text/plain", logContent.getBytes()
+        );
+
+        LogAnalysisResponseDTO result = service.runAnalysis(validFile);
+
+        assertEquals("success", result.getStatus());
+        assertEquals("Analysis completed successfully", result.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary
- Added AnomalyDetectorTest with 3 test cases
- Added IncidentCorrelatorTest with 4 test cases
- Added LogAnalysisServiceTest with 3 test cases using Mockito

## Test Coverage
- Empty input handling
- Anomaly detection on spike data
- Normal data produces no anomalies
- Consecutive minutes grouped into one incident
- Non consecutive minutes create separate incidents
- Empty/null file returns failed response

## How to run
./mvnw test
or manually run by double clicking on play icon on respective test method 