### PR TITLE
feat: add global exception handler with consistent error responses

### DIFF
--- a/src/main/java/com/nirmala/logsense/dto/ErrorResponseDTO.java
+++ b/src/main/java/com/nirmala/logsense/dto/ErrorResponseDTO.java
@@ -1,0 +1,12 @@
+package com.nirmala.logsense.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorResponseDTO {
+    private String status;
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/nirmala/logsense/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nirmala/logsense/exception/GlobalExceptionHandler.java
@@ -1,0 +1,79 @@
+package com.nirmala.logsense.exception;
+
+import com.nirmala.logsense.dto.ErrorResponseDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // handles empty file
+    @ExceptionHandler(EmptyLogFileException.class)
+    public ResponseEntity<ErrorResponseDTO> handleEmptyFile(EmptyLogFileException e) {
+        log.error("Empty file error: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)  // 400
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "EMPTY_LOG_FILE",
+                        e.getMessage()
+                ));
+    }
+
+    // handles log parse errors
+    @ExceptionHandler(LogParseException.class)
+    public ResponseEntity<ErrorResponseDTO> handleLogParse(LogParseException e) {
+        log.error("Log parse error: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.UNPROCESSABLE_ENTITY)  // 422
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "LOG_PARSE_ERROR",
+                        e.getMessage()
+                ));
+    }
+
+    // handles analysis errors
+    @ExceptionHandler(LogAnalysisException.class)
+    public ResponseEntity<ErrorResponseDTO> handleAnalysisError(LogAnalysisException e) {
+        log.error("Analysis error: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)  // 500
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "ANALYSIS_FAILED",
+                        e.getMessage()
+                ));
+    }
+
+    // handles file too large
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<ErrorResponseDTO> handleFileTooLarge(MaxUploadSizeExceededException e) {
+        log.error("File too large: {}", e.getMessage());
+        return ResponseEntity
+                .status(HttpStatus.PAYLOAD_TOO_LARGE)  // 413
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "FILE_TOO_LARGE",
+                        "Uploaded file exceeds maximum allowed size"
+                ));
+    }
+
+    // catches everything else — fallback
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponseDTO> handleGeneral(Exception e) {
+        log.error("Unexpected error: {}", e.getMessage(), e);
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)  // 500
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "INTERNAL_ERROR",
+                        "An unexpected error occurred"
+                ));
+    }
+}

--- a/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
+++ b/src/main/java/com/nirmala/logsense/service/LogAnalysisService.java
@@ -50,7 +50,7 @@ public class LogAnalysisService {
     // PUBLIC — orchestrates the full pipeline
     // ─────────────────────────────────────────
     public LogAnalysisResponseDTO runAnalysis(MultipartFile file) {
-        try {
+
             validateFile(file);
 
             Aggregator aggregator = context.getBean(Aggregator.class);
@@ -70,15 +70,6 @@ public class LogAnalysisService {
                     anomalyMap,
                     incidents
             );
-
-        } catch (EmptyLogFileException e) {
-            log.error("Empty file error: {}", e.getMessage());
-            return buildFailureResponse(e.getMessage());
-
-        } catch (Exception e) {
-            log.error("Analysis failed: {}", e.getMessage(), e);
-            return buildFailureResponse("Analysis failed: " + e.getMessage());
-        }
     }
 
     // ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Created GlobalExceptionHandler using @RestControllerAdvice
- Created ErrorResponseDTO for consistent error response structure
- Added specific handlers for EmptyLogFileException, LogParseException,
  LogAnalysisException, MaxUploadSizeExceededException
- Added generic fallback handler for unexpected errors
- Removed redundant try/catch from runAnalysis() — GlobalExceptionHandler 
  handles it centrally
- Replaced RuntimeException with LogAnalysisException in parseAndAggregate()

## Why
Without a global handler every exception returned Spring's default 500 
response with no meaningful information. Now every exception maps to a 
specific HTTP status code and returns a consistent JSON response that 
API callers can act on.

Also removed duplicate error handling from runAnalysis() — services 
should focus on business logic, not building HTTP error responses. 
That responsibility now belongs entirely to GlobalExceptionHandler.

## Test Plan
- [ ] Upload empty file — should return 400 with EMPTY_LOG_FILE code
- [ ] Upload valid file — should still return 200 with success response
- [ ] Upload file exceeding size limit — should return 413
- [ ] Verify stack traces are not exposed in any error response
- [ ] Check all error responses follow same JSON structure