### PR TITLE
Add live log ingestion endpoint

### DIFF
--- a/src/main/java/com/nirmala/logsense/controller/LogAnalysisController.java
+++ b/src/main/java/com/nirmala/logsense/controller/LogAnalysisController.java
@@ -1,31 +1,40 @@
 package com.nirmala.logsense.controller;
 
+import com.nirmala.logsense.dto.LiveIngestRequestDTO;
+import com.nirmala.logsense.dto.LiveIngestResponseDTO;
 import com.nirmala.logsense.dto.LogAnalysisResponseDTO;
 import com.nirmala.logsense.service.LogAnalysisService;
+import com.nirmala.logsense.service.LiveLogIngestionService;
+import jakarta.validation.Valid;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-
-import java.util.HashMap;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/api/logs")
 public class LogAnalysisController {
 
     private final LogAnalysisService logService;
+    private final LiveLogIngestionService liveLogIngestionService;
 
-    public LogAnalysisController(LogAnalysisService logService) {
+    public LogAnalysisController(
+            LogAnalysisService logService,
+            LiveLogIngestionService liveLogIngestionService) {
         this.logService = logService;
+        this.liveLogIngestionService = liveLogIngestionService;
     }
 
     @PostMapping(value = "/analyze", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public LogAnalysisResponseDTO analyzeLogs(@RequestPart("file") MultipartFile file) {
-        Map<String, String> response = new HashMap<>();
         return logService.runAnalysis(file);
+    }
 
+    @PostMapping(value = "/ingest", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public LiveIngestResponseDTO ingestLog(@Valid @RequestBody LiveIngestRequestDTO request) {
+        return liveLogIngestionService.ingest(request);
     }
 }

--- a/src/main/java/com/nirmala/logsense/dto/LiveIngestRequestDTO.java
+++ b/src/main/java/com/nirmala/logsense/dto/LiveIngestRequestDTO.java
@@ -1,0 +1,34 @@
+package com.nirmala.logsense.dto;
+
+import com.nirmala.logsense.model.LogModel;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.Instant;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LiveIngestRequestDTO {
+
+    @NotNull(message = "timestamp is required")
+    private Instant timestamp;
+
+    @NotBlank(message = "level is required")
+    private String level;
+
+    @NotBlank(message = "service is required")
+    private String service;
+
+    private String errorCode;
+
+    @NotBlank(message = "message is required")
+    private String message;
+
+    public LogModel toLogModel() {
+        return new LogModel(timestamp, level, service, errorCode, message);
+    }
+}

--- a/src/main/java/com/nirmala/logsense/dto/LiveIngestResponseDTO.java
+++ b/src/main/java/com/nirmala/logsense/dto/LiveIngestResponseDTO.java
@@ -1,0 +1,20 @@
+package com.nirmala.logsense.dto;
+
+import com.nirmala.logsense.model.Incident;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Data
+public class LiveIngestResponseDTO {
+
+    private String status;
+    private String message;
+    private int totalLines;
+    private boolean anomalyDetected;
+    private Instant ingestedMinute;
+    private Map<String, Map<String, List<Instant>>> anomalies;
+    private Map<String, Map<String, List<Incident>>> incidents;
+}

--- a/src/main/java/com/nirmala/logsense/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/nirmala/logsense/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.nirmala.logsense.dto.ErrorResponseDTO;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
@@ -61,6 +62,23 @@ public class GlobalExceptionHandler {
                         "error",
                         "FILE_TOO_LARGE",
                         "Uploaded file exceeds maximum allowed size"
+                ));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponseDTO> handleValidationError(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getFieldErrors().stream()
+                .findFirst()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .orElse("Request validation failed");
+
+        log.error("Validation error: {}", message);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponseDTO(
+                        "error",
+                        "VALIDATION_ERROR",
+                        message
                 ));
     }
 

--- a/src/main/java/com/nirmala/logsense/service/LiveLogIngestionService.java
+++ b/src/main/java/com/nirmala/logsense/service/LiveLogIngestionService.java
@@ -1,0 +1,128 @@
+package com.nirmala.logsense.service;
+
+import com.nirmala.logsense.aggregator.Aggregator;
+import com.nirmala.logsense.config.AnomalyDetectionConfig;
+import com.nirmala.logsense.correlator.IncidentCorrelator;
+import com.nirmala.logsense.detector.AnomalyDetector;
+import com.nirmala.logsense.dto.LiveIngestRequestDTO;
+import com.nirmala.logsense.dto.LiveIngestResponseDTO;
+import com.nirmala.logsense.explainer.IncidentExplainer;
+import com.nirmala.logsense.model.Incident;
+import com.nirmala.logsense.model.LogModel;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+public class LiveLogIngestionService {
+
+    private final Aggregator liveAggregator = new Aggregator();
+    private final AnomalyDetector detector;
+    private final IncidentCorrelator correlator;
+    private final IncidentExplainer explainer;
+    private final AnomalyDetectionConfig config;
+
+    public LiveLogIngestionService(
+            AnomalyDetector detector,
+            IncidentCorrelator correlator,
+            IncidentExplainer explainer,
+            AnomalyDetectionConfig config) {
+        this.detector = detector;
+        this.correlator = correlator;
+        this.explainer = explainer;
+        this.config = config;
+    }
+
+    public synchronized LiveIngestResponseDTO ingest(LiveIngestRequestDTO request) {
+        LogModel logModel = request.toLogModel();
+        Instant minuteBucket = logModel.getTimestamp().truncatedTo(ChronoUnit.MINUTES);
+
+        liveAggregator.add(logModel);
+        liveAggregator.setTotalLines(liveAggregator.getTotalLines() + 1);
+
+        Map<String, Map<String, List<Instant>>> anomalies =
+                detector.detect(liveAggregator.getErrorCount(), config);
+        Map<String, Map<String, List<Incident>>> incidents =
+                correlator.group(anomalies);
+
+        explainIncidents(incidents);
+
+        boolean anomalyDetected = isAnomalyForCurrentLog(
+                anomalies,
+                logModel.getService(),
+                logModel.getErrorCode(),
+                minuteBucket
+        );
+
+        log.info("Live log ingested. service={}, errorCode={}, minute={}, anomalyDetected={}",
+                logModel.getService(), logModel.getErrorCode(), minuteBucket, anomalyDetected);
+
+        return buildResponse(
+                liveAggregator.getTotalLines(),
+                minuteBucket,
+                anomalyDetected,
+                anomalies,
+                incidents
+        );
+    }
+
+    private void explainIncidents(Map<String, Map<String, List<Incident>>> incidents) {
+        for (Map.Entry<String, Map<String, List<Incident>>> serviceEntry : incidents.entrySet()) {
+            String service = serviceEntry.getKey();
+
+            for (Map.Entry<String, List<Incident>> errorEntry : serviceEntry.getValue().entrySet()) {
+                String errorCode = errorEntry.getKey();
+
+                for (Incident incident : errorEntry.getValue()) {
+                    explainer.explainIncident(
+                            service,
+                            errorCode,
+                            incident,
+                            liveAggregator.getErrorLogs()
+                    );
+                }
+            }
+        }
+    }
+
+    private boolean isAnomalyForCurrentLog(
+            Map<String, Map<String, List<Instant>>> anomalies,
+            String service,
+            String errorCode,
+            Instant minuteBucket) {
+
+        if (!anomalies.containsKey(service)) {
+            return false;
+        }
+
+        Map<String, List<Instant>> anomaliesByErrorCode = anomalies.get(service);
+        if (!anomaliesByErrorCode.containsKey(errorCode)) {
+            return false;
+        }
+
+        return anomaliesByErrorCode.get(errorCode).contains(minuteBucket);
+    }
+
+    private LiveIngestResponseDTO buildResponse(
+            int totalLines,
+            Instant ingestedMinute,
+            boolean anomalyDetected,
+            Map<String, Map<String, List<Instant>>> anomalies,
+            Map<String, Map<String, List<Incident>>> incidents) {
+
+        LiveIngestResponseDTO response = new LiveIngestResponseDTO();
+        response.setStatus("success");
+        response.setMessage("Log ingested successfully");
+        response.setTotalLines(totalLines);
+        response.setIngestedMinute(ingestedMinute);
+        response.setAnomalyDetected(anomalyDetected);
+        response.setAnomalies(anomalies);
+        response.setIncidents(incidents);
+        return response;
+    }
+}


### PR DESCRIPTION
## Summary
- Added `POST /api/logs/ingest` for live JSON log ingestion
- Added request/response DTOs for live log events
- Reused the existing aggregation, anomaly detection, incident correlation, and explanation pipeline
- Added validation handling for invalid live ingest payloads

## Behavior
Each ingested log is added to an in-memory live aggregation. The service recalculates anomalies after every request and returns whether the ingested minute is currently anomalous.

## Notes
- Live ingestion state is currently in memory and resets when the application restarts
- Existing file upload analysis endpoint remains unchanged

## Testing
- Tested manually through Swagger using `POST /api/logs/ingest`
